### PR TITLE
Revert "Use gradle 3.2.1 (#1)"

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,10 @@
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:2.3.1'
     }
 }
 


### PR DESCRIPTION
This reverts commit 31e64fab8ae66833d8171624a9e6a900d628a129.

We fixed this in keybase/client instead.